### PR TITLE
fix: move dev dependencies from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,18 +33,18 @@
   "description": "A tool to sync models with Notion.",
   "dependencies": {
     "@notionhq/client": "^2.2.15",
-    "@types/jest": "^29.5.14",
-    "@types/node": "^22.10.2",
     "chalk": "^5.4.1",
     "commander": "^12.1.0",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.2",
     "eslint": "^9.18.0",
     "globals": "^15.14.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.19.1"
   },


### PR DESCRIPTION
This PR fixes issue #20 by moving development-only packages from `dependencies` to `devDependencies`.

## Changes
- Move `@types/jest` to devDependencies
- Move `@types/node` to devDependencies
- Move `jest` to devDependencies
- Move `ts-jest` to devDependencies

This reduces production bundle size by keeping development-only packages in devDependencies.

Closes #20

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency categorization to improve package management. No impact on app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->