### PR TITLE
fix: resolve TypeScript and Jest configuration conflict

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "generated", "sample.ts", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "tests", "generated", "sample.ts"]
 }


### PR DESCRIPTION
This PR resolves the configuration conflict between TypeScript and Jest where tsconfig.json was excluding test files but Jest was targeting them.

## Changes
- Removed `**/*.test.ts` from tsconfig.json exclude list
- TypeScript now compiles test files, allowing proper IDE support and Jest execution

## Benefits
- Resolves IDE type checking issues in test files
- Ensures consistent build and test execution
- Simplified unified configuration approach

Fixes #25

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project configuration to include test files in the TypeScript compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->