### PR TITLE
feat: add comprehensive Jest coverage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 generated
 dist/
 .env
+
+# Coverage reports
+coverage/
+*.lcov

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,4 +15,35 @@ module.exports = {
   },
   testMatch: ["**/src/**/*.test.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  
+  // Coverage configuration
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "html", "text-summary"],
+  collectCoverageFrom: [
+    "src/**/*.{ts,tsx}",
+    "!src/**/*.test.{ts,tsx}",
+    "!src/**/*.d.ts",
+    "!src/**/index.ts",
+    "!dist/**",
+    "!generated/**",
+    "!coverage/**",
+    "!node_modules/**",
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "/dist/",
+    "/generated/",
+    "/coverage/",
+    "\\.test\\.",
+    "\\.d\\.ts$",
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "lint": "eslint .",
     "generate": "ts-node src/cli.ts generate",
     "create-databases": "ts-node src/cli.ts create-databases",


### PR DESCRIPTION
Issue #41: テストカバレッジレポートの設定

## Summary
- Add comprehensive Jest coverage configuration with 80% threshold
- Enable HTML, LCOV, and text reporting formats
- Exclude test files, generated files, and build artifacts
- Add test:coverage script and update .gitignore

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a script to generate test coverage reports using Jest.
- **Chores**
  - Updated configuration to enable and customize code coverage reporting, including coverage thresholds and report formats.
  - Updated ignore rules to exclude coverage files and directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->